### PR TITLE
[8] include yaml, add tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,4 @@
-name: Run tests
+name: Verify grjobs setup.py
 
 on:
   pull_request:
@@ -15,26 +15,25 @@ jobs:
           - macos-latest
         python-version:
           - '3.8'
+          
     runs-on: ${{ matrix.os }}
-    name: Run pytest
+    name: Check the installation builds
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-
-      - name: Install local package
+      
+      - name: Install
         run: |
-          pip install wheel
-          pip install .
+          pip install --user wheel
+          pip install --user https://github.com/nestauk/grjobs/archive/${{ github.head_ref }}.zip
 
-      - name: Check that can be imported
+      - name: Install libomp for MacOS
+        if: runner.os == 'macOS'
+        run: brew install libomp
+          
+      - name: Check that installation has worked
         run: |
-          cd $HOME
-          mkdir test_dir
-          cd test_dir
           python -c "import grjobs"
           python -c "from grjobs.pipeline.green_classifier import load_model"

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include grjobs/config/*yaml


### PR DESCRIPTION
Closes #8, and a continuation of #9

## What this feature does

Adds the `config/*yaml` files to the installation so that `grjobs` can be installed as a third party lib. I've added a GH workflow to verify that this is now the case, but you can also verify by setting up a new conda env and doing:

```bash
pip install https://github.com/nestauk/grjobs/archive/8_yaml.zip
python -c "import grjobs"
python -c "from grjobs.pipeline.green_classifier import load_model"
```

---

Checklist:

- [ ] ~I have refactored my code out from `notebooks/`~
- [x] I have checked the code runs
- [x] I have tested the code
- [x] I have run `pre-commit` and addressed any issues not automatically fixed
- [x] I have merged any new changes from `dev`
- [ ] ~I have documented the code~
  - [ ] ~Major functions have docstrings~
  - [ ] ~Appropriate information has been added to `README`s~
- [x] I have explained the feature in this PR or (better) in `output/reports/`
- [x] I have requested a code review
